### PR TITLE
Move --logdir in command to allowed_arguments

### DIFF
--- a/python/service-defs/tensorboard.json
+++ b/python/service-defs/tensorboard.json
@@ -10,9 +10,14 @@
   "command": [
     "{runtime_path}",
     "-m", "tensorboard.main",
-    "--logdir", "/home/work/logs",
     "--host", "0.0.0.0",
     "--port", "{ports[0]}",
     "--debugger_port", "6064"
-  ]
+  ],
+  "allowed_arguments": [
+    "--logdir"
+  ],
+  "default_arguments": {
+    "--logdir": "/home/work/logs"
+  }
 }


### PR DESCRIPTION
This PR relates to a new feature in backend.ai-console that points to a directory based on the path entered by the user when starting the Tensor Board app.