### PR TITLE
fix: [ngc-pytorch:25.03] update package versions & options

### DIFF
--- a/vendor/ngc-pytorch/Dockerfile.25.03-pytorch2.7-py312-cuda12.8
+++ b/vendor/ngc-pytorch/Dockerfile.25.03-pytorch2.7-py312-cuda12.8
@@ -152,7 +152,7 @@ RUN apt-get install -y --no-install-recommends \
 	xvfb \
 	xz-utils \
 	sudo \
-	yarn \
+#	yarn \
 	yasm \
 	zip \
 	tcl \
@@ -167,10 +167,11 @@ RUN mkdir -p /opt/oracle && \
     echo /opt/oracle/instantclient* > /etc/ld.so.conf.d/oracle-instantclient.conf && \
     ldconfig && \
     cd /tmp && \
-    curl -sL https://deb.nodesource.com/setup_20.x -o /tmp/nodesource_setup.sh && \ 
-    bash /tmp/nodesource_setup.sh && \
-    apt-get update ; apt-get install -y nodejs && \
-# Install CUDA + cuDNN
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get update && apt-get install -y nodejs && \
+	corepack enable && \
+    corepack prepare yarn@stable --activate && \
+    # Install CUDA + cuDNN
     mkdir -p /usr/local/nvidia/lib && \
     ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.9.6.0 /usr/local/cuda/lib64/libcudnn.so && \
     ldconfig && \
@@ -248,7 +249,7 @@ LABEL ai.backend.kernelspec="1" \
       ai.backend.accelerators="cuda" \
       ai.backend.resource.min.cpu="1" \
       ai.backend.resource.min.mem="1g" \
-      ai.backend.resource.min.cuda.device=1 \
+      ai.backend.resource.min.cuda.device=0 \
       ai.backend.resource.min.cuda.shares=0 \
       ai.backend.runtime-type="python" \
       ai.backend.runtime-path="/usr/bin/python" \
@@ -275,7 +276,7 @@ RUN python3 -m pip install --no-cache-dir \
 	jupyter-packaging
 RUN python3 -m pip install --no-cache-dir \
 	jupyter-server-mathjax \
-	jupyter-server-proxy==1.6.0 \
+	jupyter-server-proxy>=4.0.0 \
 	jupyter-telemetry==0.1.0 \
 	jupyter==1.0.0 \
 	jupyter-client==8.6.3 \
@@ -291,15 +292,17 @@ RUN python3 -m pip install jupyter_lsp markupsafe==3.0.2 jupyterlab_widgets && \
     jupyter labextension install --no-build @jupyterlab/toc-extension && \
     jupyter labextension install --no-build @krassowski/jupyterlab-lsp && \
     jupyter labextension install @jupyterlab/toc-extension && \
-    jupyter lab build
+    jupyter lab build --dev-build=False --minimize=False 
 
-RUN apt autoclean && \
+RUN apt-get autoclean && \
     sed -i 's/source \/usr\/local\/nvm\/nvm.sh//' /etc/bash.bashrc && \
     ln -sf /usr/share/terminfo/x/xterm-color /usr/share/terminfo/x/xterm-256color && \
     rm -f /tmp/*.whl /tmp/requirem* && \
     rm -rf /var/lib/apt/lists/* && \	
     rm -rf /root/.cache && \
     rm -rf /tmp/*
-    
+
+# change permission
+RUN chown root:root /usr/lib
 
 WORKDIR /home/work

--- a/vendor/ngc-pytorch/requirements.25.03.txt
+++ b/vendor/ngc-pytorch/requirements.25.03.txt
@@ -13,7 +13,7 @@ PyQt5-sip==12.16.1
 PyQt5==5.15.0
 PyQtWebEngine==5.15.2
 PyVirtualDisplay==1.3.2
-PyWavelets==1.1.1
+PyWavelets>=1.4.1
 PythonWebHDFS==0.2.3
 QtPy==1.9.0
 SQLAlchemy==1.4.36
@@ -63,7 +63,7 @@ dash-core-components==2.0.0
 dash-html-components==2.0.0
 dash-table==5.0.0
 dash==2.3.1
-databricks-cli==0.17.2
+databricks-cli==0.18.0
 deap==1.4.1
 deepdish==0.3.6
 deepmerge==0.1.0
@@ -112,7 +112,7 @@ huggingface-hub>=0.4.0
 hyperopt==0.1.2
 imageio==2.36.1
 imbalanced-learn==0.5.0
-ipywidgets==7.5.1
+ipywidgets==7.8.5
 iso8601==1.0.2
 isort>=6.0.1
 itsdangerous==2.2.0
@@ -211,7 +211,7 @@ python-xlib==0.31
 pythran==0.17.0
 pytoolconfig==1.2.2
 pyvista==0.41.1
-pyvo==1.0
+pyvo==1.7
 qgrid==1.3.1
 qtconsole==4.7.1
 qudida==0.0.4
@@ -259,7 +259,7 @@ tokenizers>=0.11.1
 tomlkit==0.10.2
 #torch-struct==0.5
 #torchfile==0.1.0
-transformers==4.47.1
+transformers==4.55.2
 tweepy==3.8.0
 typeguard>=4.3.0
 typing==3.7.4.1
@@ -273,7 +273,7 @@ vtk==9.4.1
 webargs==8.1.0
 websocket-client>=1.8.0
 websockets==10.3
-widgetsnbextension==3.5.1
+widgetsnbextension==3.6.10
 wrapt==1.17.2
 wslink==1.6.6
 yapf==0.43.0


### PR DESCRIPTION
update package versions & options
- installed npm and yarn manually (instead of using the default Ubuntu packages)
- upgrade jupyterlab related package versions
- change resource option: `ai.backend.resource.min.cuda.device` value 1 to 0
- change permission: `/usr/lib` value ubuntu to root