### PR TITLE
Add R 4.6.1 Docker image with Jupyter and RStudio support

### DIFF
--- a/r-base/Dockerfile.4.6.1
+++ b/r-base/Dockerfile.4.6.1
@@ -73,11 +73,10 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 2
 ENV USER work
 ENV PASSWORD work
 ENV DISABLE_AUTH true
-# Do NOT set USERID/GROUPID=1100: the rocker/rstudio base's own cont-init
-# (02_userconf) reads them and recreates the rstudio user at that UID, which
-# then mismatches the UID 1000 Backend.AI runs the session as (breaking rsession
-# spawn -> app-proxy ServerDisconnectedError). Leaving them unset keeps the base
-# rstudio user at UID 1000, matching Backend.AI.
+# Do NOT set USERID/GROUPID: 02_userconf defaults them to 1000, which matches
+# the uid Backend.AI creates `work` with, so it skips its userdel/useradd branch
+# and leaves the entrypoint-created account alone.  Setting them to anything
+# else makes cont-init delete and recreate the account underneath RStudio.
 
 # S6_VERSION and RSTUDIO_VERSION are already exported by the rocker/rstudio base
 # image (identical on amd64 and arm64), so they are intentionally not redefined
@@ -104,13 +103,36 @@ RUN Rscript -e "IRkernel::installspec(displayname = 'R-base 4.6.1 on Backend.AI'
 # / `jupyter labextension install` / `jupyter lab build` steps are removed (those
 # subcommands no longer exist and would fail the build).
 
+# Vacate uid/gid 1000 for Backend.AI.
+#
+# The rocker/rstudio base ships an `rstudio` account at uid/gid 1000, which is
+# exactly the uid Backend.AI runs sessions as.  When Backend.AI's entrypoint
+# finds an existing account at $LOCAL_USER_ID it takes its "merge the image home
+# directory" branch and runs `usermod -l work rstudio`, i.e. it *renames* the
+# base account (the stray `cp: cannot stat '/home/rstudio/*'` lines in the
+# session log come from that same branch).  The rocker cont-init scripts then
+# configure RStudio for a user named `rstudio` that no longer exists, so rserver
+# cannot spawn an rsession and app-proxy reports ServerDisconnectedError.
+#
+# Moving the base account out of the way makes the entrypoint take its clean
+# `useradd work -u 1000` branch instead: nothing is renamed and nothing is
+# copied.
+RUN usermod -u 1100 rstudio && \
+    groupmod -g 1100 rstudio && \
+    chown -R 1100:1100 /home/rstudio
+
 COPY ./service-defs /etc/backend.ai/service-defs
-COPY ./bootstrap_rocker2.sh /opt/container/bootstrap.sh
+COPY ./bootstrap_rstudio.sh /opt/container/bootstrap.sh
 RUN chmod +x /opt/container/bootstrap.sh
 # The rocker/rstudio base already provides its own cont-init user/auth handling
 # (01_set_env + 02_userconf); do NOT install userconf_backendai.sh (built for the
 # older rocker/r-ver flow) — running both left RStudio without a valid session
-# user and re-enabled auth, breaking the RStudio app.
+# user and re-enabled auth, breaking the RStudio app.  The base scripts do the
+# right thing once DEFAULT_USER=work and uid 1000 is free (see above).
+#
+# runtime-path is what the jupyter/jupyterlab service definitions interpolate as
+# `{runtime_path} -m notebook`, so it must be a real interpreter even though the
+# runtime-type is "app".
 LABEL ai.backend.kernelspec="1" \
       ai.backend.envs.corecount="OPENBLAS_NUM_THREADS,OMP_NUM_THREADS,NPROC" \
       ai.backend.features="batch query uid-match user-input" \
@@ -118,8 +140,14 @@ LABEL ai.backend.kernelspec="1" \
       ai.backend.resource.min.mem="256m" \
       ai.backend.base-distro="ubuntu24.04" \
       ai.backend.runtime-type="app" \
-      ai.backend.runtime-path="/bin/false" \
+      ai.backend.runtime-path="/usr/bin/python3" \
       ai.backend.service-ports="ipython:pty:3000,jupyter:http:8080,jupyterlab:http:8090,rstudio:preopen:8787"
+
+# DEFAULT_USER is the knob the base 02_userconf uses to pick the RStudio login
+# account (`USER=${DEFAULT_USER}` — it ignores an inherited $USER).  Pointing it
+# at `work` makes cont-init write `USER=work` into /etc/environment, which is
+# what /etc/services.d/rstudio/run feeds to rserver for the auth-none login.
+ENV DEFAULT_USER work
 ENV USER work
 ENV PASSWORD work
 ENV DISABLE_AUTH true

--- a/r-base/Dockerfile.4.6.1
+++ b/r-base/Dockerfile.4.6.1
@@ -1,0 +1,121 @@
+FROM rocker/rstudio:4.6.1
+
+ENV R_VERSION 4.6.1
+ENV GIT_LFS_VERSION 3.7.1
+
+# rocker/rstudio (Ubuntu 24.04) enforces PEP 668; allow pip to install into the
+# system environment.
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+WORKDIR /tmp
+RUN apt-get update && \
+    apt-get install -y \
+        ca-certificates \
+        wget curl git-core sudo \
+        python3 python3-dev python3-pip python3-venv \
+        libssl-dev \
+        proj-bin libproj-dev \
+        libgeos-dev libgeos++-dev \
+        media-types \
+        locales \
+        fonts-texgyre \
+        fonts-nanum \
+        fonts-nanum-coding \
+        fonts-nanum-extra \
+        htop \
+        less \
+        vim-tiny \
+        liblapack3 \
+        libzmq3-dev \
+        ncurses-term \
+        cmake gcc g++ gfortran && \
+    ln -sf /usr/share/terminfo/x/xterm-color /usr/share/terminfo/x/xterm-256color && \
+    curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get update -y && \
+    apt-get install -y nodejs && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install git-lfs (auto-detect arch so the image builds on amd64 and arm64)
+RUN cd /tmp && \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) tarArch='amd64';; \
+        arm64) tarArch='arm64';; \
+        *) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding binary release"; exit 1 ;; \
+    esac; \
+    curl -sLO "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${tarArch}-v${GIT_LFS_VERSION}.tar.gz" && \
+    tar -zxf "git-lfs-linux-${tarArch}-v${GIT_LFS_VERSION}.tar.gz" && \
+    cd git-lfs-*  && \
+    bash install.sh && \
+    rm -rf /tmp/*
+
+# passwordless sudo for the Backend.AI work user
+RUN echo "work ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Install commonly-used wheels. Do not `pip install --upgrade pip` here: on
+# Ubuntu 24.04 pip is apt-managed (dpkg) and lacks a RECORD file, so pip cannot
+# uninstall it and the build fails. The apt pip is new enough.
+RUN python3 -m pip install --no-cache-dir ipython && \
+    python3 -m pip install --no-cache-dir jupyter && \
+    python3 -m pip install --no-cache-dir ipywidgets && \
+    python3 -m pip install --no-cache-dir ipyparallel && \
+    python3 -m pip install --no-cache-dir jupyterlab && \
+    python3 -m pip install --no-cache-dir jupyterthemes && \
+    python3 -m pip install --no-cache-dir jupyter-js-widgets-nbextension && \
+    rm -rf /root/.cache && \
+    rm -f /tmp/*.whl
+
+# python alternative support
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 2
+
+ENV USER work
+ENV PASSWORD work
+ENV USERID 1100
+ENV GROUPID 1100
+ENV DISABLE_AUTH true
+
+# S6_VERSION and RSTUDIO_VERSION are already exported by the rocker/rstudio base
+# image (identical on amd64 and arm64), so they are intentionally not redefined
+# here — the base value is inherited automatically.
+
+## RStudio is already bundled in the rocker/rstudio base image, so we only
+## install pandoc and tidyverse/devtools here.
+RUN /rocker_scripts/install_pandoc.sh
+
+# Devtools is installed here.
+RUN /rocker_scripts/install_tidyverse.sh
+
+RUN Rscript -e "install.packages(c('rzmq','repr','IRkernel','IRdisplay'))" && \
+    Rscript -e "install.packages(c('slidify','ggplot2'))" && \
+    Rscript -e "install.packages(c('jsonlite','jsonview','XML','xml2','xmlview'))" && \
+    Rscript -e "install.packages(c('igraph'))"
+
+RUN Rscript -e "IRkernel::installspec(displayname = 'R-base 4.6.1 on Backend.AI' , user = FALSE)" && \
+    rm -rf /root/.local/share/jupyter && \
+    jupyter kernelspec list && \
+    cat /usr/local/share/jupyter/kernels/ir/kernel.json
+# Note: JupyterLab 4 ships the widgets manager as a prebuilt (pip) extension and
+# auto-enables server extensions, so the legacy `jupyter serverextension enable`
+# / `jupyter labextension install` / `jupyter lab build` steps are removed (those
+# subcommands no longer exist and would fail the build).
+
+COPY ./service-defs /etc/backend.ai/service-defs
+COPY ./bootstrap_rocker2.sh /opt/container/bootstrap.sh
+RUN chmod +x /opt/container/bootstrap.sh
+COPY ./userconf_backendai.sh /rocker_scripts/userconf.sh
+COPY ./userconf_backendai.sh /etc/cont-init.d/userconf
+LABEL ai.backend.kernelspec="1" \
+      ai.backend.envs.corecount="OPENBLAS_NUM_THREADS,OMP_NUM_THREADS,NPROC" \
+      ai.backend.features="batch query uid-match user-input" \
+      ai.backend.resource.min.cpu="1" \
+      ai.backend.resource.min.mem="256m" \
+      ai.backend.base-distro="ubuntu24.04" \
+      ai.backend.runtime-type="r" \
+      ai.backend.runtime-path="/usr/bin/python3" \
+      ai.backend.service-ports="ipython:pty:3000,jupyter:http:8080,jupyterlab:http:8090,rstudio:preopen:8787"
+ENV USER work
+ENV PASSWORD work
+ENV DISABLE_AUTH true
+
+WORKDIR /home/work

--- a/r-base/Dockerfile.4.6.1
+++ b/r-base/Dockerfile.4.6.1
@@ -112,8 +112,8 @@ LABEL ai.backend.kernelspec="1" \
       ai.backend.resource.min.cpu="1" \
       ai.backend.resource.min.mem="256m" \
       ai.backend.base-distro="ubuntu24.04" \
-      ai.backend.runtime-type="r" \
-      ai.backend.runtime-path="/usr/bin/python3" \
+      ai.backend.runtime-type="app" \
+      ai.backend.runtime-path="/bin/false" \
       ai.backend.service-ports="ipython:pty:3000,jupyter:http:8080,jupyterlab:http:8090,rstudio:preopen:8787"
 ENV USER work
 ENV PASSWORD work

--- a/r-base/Dockerfile.4.6.1
+++ b/r-base/Dockerfile.4.6.1
@@ -72,9 +72,12 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 2
 
 ENV USER work
 ENV PASSWORD work
-ENV USERID 1100
-ENV GROUPID 1100
 ENV DISABLE_AUTH true
+# Do NOT set USERID/GROUPID=1100: the rocker/rstudio base's own cont-init
+# (02_userconf) reads them and recreates the rstudio user at that UID, which
+# then mismatches the UID 1000 Backend.AI runs the session as (breaking rsession
+# spawn -> app-proxy ServerDisconnectedError). Leaving them unset keeps the base
+# rstudio user at UID 1000, matching Backend.AI.
 
 # S6_VERSION and RSTUDIO_VERSION are already exported by the rocker/rstudio base
 # image (identical on amd64 and arm64), so they are intentionally not redefined
@@ -104,8 +107,10 @@ RUN Rscript -e "IRkernel::installspec(displayname = 'R-base 4.6.1 on Backend.AI'
 COPY ./service-defs /etc/backend.ai/service-defs
 COPY ./bootstrap_rocker2.sh /opt/container/bootstrap.sh
 RUN chmod +x /opt/container/bootstrap.sh
-COPY ./userconf_backendai.sh /rocker_scripts/userconf.sh
-COPY ./userconf_backendai.sh /etc/cont-init.d/userconf
+# The rocker/rstudio base already provides its own cont-init user/auth handling
+# (01_set_env + 02_userconf); do NOT install userconf_backendai.sh (built for the
+# older rocker/r-ver flow) — running both left RStudio without a valid session
+# user and re-enabled auth, breaking the RStudio app.
 LABEL ai.backend.kernelspec="1" \
       ai.backend.envs.corecount="OPENBLAS_NUM_THREADS,OMP_NUM_THREADS,NPROC" \
       ai.backend.features="batch query uid-match user-input" \

--- a/r-base/Dockerfile.4.6.1
+++ b/r-base/Dockerfile.4.6.1
@@ -26,6 +26,7 @@ RUN apt-get update && \
         less \
         vim-tiny \
         liblapack3 \
+        libglpk-dev \
         libzmq3-dev \
         ncurses-term \
         cmake gcc g++ gfortran && \

--- a/r-base/bootstrap_rstudio.sh
+++ b/r-base/bootstrap_rstudio.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Backend.AI image bootstrap for the rocker/rstudio-based r-base images.
+#
+# It is sourced as root by /opt/kernel/entrypoint.sh after the `work` account
+# (uid=$LOCAL_USER_ID) has been created and before the kernel runner starts.
+
+# R's site-library is group-writable by `staff`; the base only adds its own
+# default user to it, so add the Backend.AI user here.
+if id -u work > /dev/null 2>&1; then
+    usermod -aG staff work
+fi
+
+mkdir -p /home/work/.rstudio-server
+chown "${LOCAL_USER_ID:-1000}:${LOCAL_GROUP_ID:-1000}" /home/work/.rstudio-server
+
+# Hand over to the rocker s6 supervision tree: it runs /etc/cont-init.d/*
+# (01_set_env, 02_userconf) and then supervises rserver on port 8787.
+/init &


### PR DESCRIPTION
## Summary
This PR adds a new Dockerfile for R 4.6.1 based on the rocker/rstudio base image, configured for Backend.AI kernel execution with integrated Jupyter and RStudio support.

## Key Changes
- **New Dockerfile**: `r-base/Dockerfile.4.6.1` - Complete R 4.6.1 runtime environment
- **System dependencies**: Installs essential build tools, geospatial libraries (GEOS, PROJ), Node.js 20, and development headers
- **Git LFS support**: Adds Git LFS 3.7.1 with architecture auto-detection for amd64 and arm64
- **Python integration**: Installs Python 3 with Jupyter, JupyterLab, IPython, and related packages
- **R packages**: Installs IRkernel, tidyverse, devtools, and common data science packages (ggplot2, igraph, XML utilities, etc.)
- **Backend.AI configuration**: 
  - Adds service definitions and bootstrap scripts for Backend.AI integration
  - Configures kernel spec for "R-base 4.6.1 on Backend.AI"
  - Sets up passwordless sudo for the work user
  - Defines resource requirements and service ports (Jupyter, JupyterLab, RStudio)
- **Environment setup**: Configures PEP 668 compliance, locale support, and font packages for rendering

## Notable Implementation Details
- Uses rocker/rstudio:4.6.1 as base image (Ubuntu 24.04)
- Git LFS installation uses dpkg architecture detection to support multiple platforms
- Avoids upgrading pip to maintain compatibility with apt-managed Python on Ubuntu 24.04
- Disables JupyterLab legacy extension installation (JupyterLab 4 uses prebuilt extensions)
- Sets up both RStudio and Jupyter/JupyterLab as accessible services on ports 8787, 8080, and 8090

https://claude.ai/code/session_01Sp9TL1oFffSeH17nAfAszT